### PR TITLE
Remove 'Insufficient balance' message from success notification

### DIFF
--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -33,8 +33,7 @@ class Sidebar extends React.Component {
       .then(() => {
         this.props.addNotification({
           title: 'Ditt kjøp ble gjennomført!',
-          level: 'success',
-          message: this.props.error
+          level: 'success'
         });
         this.props.clearCustomer();
       })


### PR DESCRIPTION
After a successful purchase, the last error message received was shown in the notification, even though the user had sufficient balance
